### PR TITLE
fixing variable warning seen in Puppet 3.8

### DIFF
--- a/templates/masterha_default.cnf.erb
+++ b/templates/masterha_default.cnf.erb
@@ -16,7 +16,7 @@ ssh_options=<%= @ssh_options %>
 skip_reset_slave=<%= @skip_reset_slave %>
 <% end -%>
 <% if @mysql_user != '' -%>
-user = <%= mysql_user %>
+user = <%= @mysql_user %>
 <% end -%>
 <% if @mysql_password != '' -%>
 password=<%= @mysql_password %>


### PR DESCRIPTION
Warning: Variable access via 'mysql_user' is deprecated. Use '@mysql_user' instead. template[/etc/puppet/modules/mha/templates/masterha_default.cnf.erb]:19
